### PR TITLE
Enable Chrome debugging for WebViews

### DIFF
--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2BasicWebView.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2BasicWebView.kt
@@ -23,6 +23,7 @@ import android.widget.PopupWindow
 import android.widget.TextView
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
+import org.readium.r2.navigator.BuildConfig
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.R2EpubActivity
 import org.readium.r2.shared.Locations
@@ -43,6 +44,9 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
 
     var callback: OnOverScrolledCallback? = null
 
+    init {
+      WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
+    }
 
     interface OnOverScrolledCallback {
         fun onOverScrolled(scrollX: Int, scrollY: Int, clampedX: Boolean, clampedY: Boolean)


### PR DESCRIPTION
This change will allow us to use the Chrome Developer tools on a WebView when we run in debug mode. This makes it easier to inspect the DO, CSS, access the JS console and all the other thing we like with web development. :)

See https://developers.google.com/web/tools/chrome-devtools/remote-debugging/webviews for details.