### PR TITLE
Clean up PageProgressionDirection uses, use global variable to pass data to activities

### DIFF
--- a/r2-navigator/src/main/java/org/readium/r2/navigator/GlobalVars.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/GlobalVars.kt
@@ -9,6 +9,8 @@
 
 package org.readium.r2.navigator
 
+import org.readium.r2.shared.Publication
+
 /**
  * Created by aferditamuriqi on 10/3/17.
  */
@@ -19,3 +21,12 @@ package org.readium.r2.navigator
  */
 const val BASE_URL = "http://127.0.0.1"
 
+class PublicationData(
+        val path: String,
+        val publication: Publication,
+        val fileName: String?,
+        val bookId: Long? = null,
+        val cover: ByteArray? = null
+)
+
+var CURRENT_PUB: PublicationData? = null

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
+import org.readium.r2.shared.PageProgressionDirection
 import org.readium.r2.shared.SCROLL_REF
 import org.readium.r2.shared.getAbsolute
 
@@ -82,7 +83,7 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
             }
             val scrollMode = listener.preferences.getBoolean(SCROLL_REF, false)
             if (scrollMode) {
-                if (listener.publication.metadata.direction == "rtl") {
+                if (listener.publication.metadata.direction == PageProgressionDirection.rtl) {
                     this@R2BasicWebView.evaluateJavascript("scrollRightRTL();") { result ->
                         if (result.contains("edge")) {
                             navigator.goBackward(animated = animated)
@@ -113,7 +114,7 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
             }
             val scrollMode = listener.preferences.getBoolean(SCROLL_REF, false)
             if (scrollMode) {
-                if (listener.publication.metadata.direction == "rtl") {
+                if (listener.publication.metadata.direction == PageProgressionDirection.rtl) {
                     this@R2BasicWebView.evaluateJavascript("scrollLeftRTL();") { result ->
                         if (result.contains("edge")) {
                             navigator.goForward(animated = animated)

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/audiobook/R2AudiobookActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/audiobook/R2AudiobookActivity.kt
@@ -91,16 +91,16 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val pub = CURRENT_PUB
+        check(pub != null)
         setContentView(R.layout.activity_r2_audiobook)
 
         preferences = getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
 
-        publicationPath = intent.getStringExtra("publicationPath") ?: throw Exception("publicationPath required")
-        publicationFileName = intent.getStringExtra("publicationFileName") ?: throw Exception("publicationFileName required")
-
-        publication = intent.getSerializableExtra("publication") as Publication
+        publicationPath = pub.path
+        publicationFileName = pub.fileName ?: throw Exception("publicationFileName required")
+        publication = pub.publication
         publicationIdentifier = publication.metadata.identifier!!
-
         title = null
 
         Handler().postDelayed({

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/R2CbzActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/R2CbzActivity.kt
@@ -81,15 +81,17 @@ open class R2CbzActivity : AppCompatActivity(), CoroutineScope, IR2Activity, Vis
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val pub = CURRENT_PUB
+        check(pub != null)
         setContentView(R.layout.activity_r2_viewpager)
 
         preferences = getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
         resourcePager = findViewById(R.id.resourcePager)
         resourcePager.type = Publication.TYPE.CBZ
 
-        publicationPath = intent.getStringExtra("publicationPath") ?: throw Exception("publicationPath required")
-        publicationFileName = intent.getStringExtra("publicationFileName") ?: throw Exception("publicationFileName required")
-        publication = intent.getSerializableExtra("publication") as Publication
+        publicationPath = pub.path
+        publicationFileName = pub.fileName  ?: throw Exception("publicationFileName required")
+        publication = pub.publication
         publicationIdentifier = publication.metadata.identifier!!
         title = publication.metadata.title
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/divina/R2DiViNaActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/divina/R2DiViNaActivity.kt
@@ -20,6 +20,7 @@ import androidx.webkit.WebViewClientCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.readium.r2.navigator.CURRENT_PUB
 import org.readium.r2.navigator.IR2Activity
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.R2BasicWebView
@@ -47,6 +48,8 @@ open class R2DiViNaActivity : AppCompatActivity(), CoroutineScope, IR2Activity {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val pub = CURRENT_PUB
+        check(pub != null)
         setContentView(R.layout.activity_r2_divina)
 
         preferences = getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
@@ -54,10 +57,9 @@ open class R2DiViNaActivity : AppCompatActivity(), CoroutineScope, IR2Activity {
         divinaWebView.activity = this
         divinaWebView.listener = this
 
-        publicationPath = intent.getStringExtra("publicationPath") ?: throw Exception("publicationPath required")
-        publicationFileName = intent.getStringExtra("publicationFileName") ?: throw Exception("publicationFileName required")
-        publication = intent.getSerializableExtra("publication") as Publication
-
+        publicationPath = pub.path
+        publicationFileName = pub.fileName  ?: throw Exception("publicationFileName required")
+        publication = pub.publication
         publicationIdentifier = publication.metadata.identifier!!
         title = publication.metadata.title
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
@@ -247,6 +247,8 @@ open class R2EpubActivity : AppCompatActivity(), IR2Activity, IR2Selectable, IR2
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val pub = CURRENT_PUB
+        check(pub != null)
         setContentView(R.layout.activity_r2_viewpager)
 
         preferences = getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
@@ -256,11 +258,10 @@ open class R2EpubActivity : AppCompatActivity(), IR2Activity, IR2Selectable, IR2
         resourcesSingle = ArrayList()
         resourcesDouble = ArrayList()
 
-        publicationPath = intent.getStringExtra("publicationPath") ?: throw Exception("publicationPath required")
-        publication = intent.getSerializableExtra("publication") as Publication
-        publicationFileName = intent.getStringExtra("publicationFileName") ?: throw Exception("publicationFileName required")
+        publicationPath = pub.path
+        publication = pub.publication
+        publicationFileName = pub.fileName  ?: throw Exception("publicationFileName required")
         publicationIdentifier = publication.metadata.identifier!!
-
         title = null
 
         val port = preferences.getString("$publicationIdentifier-publicationPort", 0.toString())?.toInt()

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
@@ -150,7 +150,7 @@ open class R2EpubActivity : AppCompatActivity(), IR2Activity, IR2Selectable, IR2
 
                 val currentFragment = ((resourcePager.adapter as R2PagerAdapter).mFragments.get((resourcePager.adapter as R2PagerAdapter).getItemId(resourcePager.currentItem))) as? R2EpubPageFragment
 
-                if (layoutDirectionIsRTL() || publication.metadata.direction == PageProgressionDirection.rtl.name) {
+                if (layoutDirectionIsRTL() || publication.metadata.direction == PageProgressionDirection.rtl) {
                     // The view has RTL layout
                     currentFragment?.webView?.let {
                         currentFragment.webView.progression = 1.0
@@ -183,7 +183,7 @@ open class R2EpubActivity : AppCompatActivity(), IR2Activity, IR2Selectable, IR2
 
                 val currentFragment = ((resourcePager.adapter as R2PagerAdapter).mFragments.get((resourcePager.adapter as R2PagerAdapter).getItemId(resourcePager.currentItem))) as? R2EpubPageFragment
 
-                if (layoutDirectionIsRTL() || publication.metadata.direction == PageProgressionDirection.rtl.name) {
+                if (layoutDirectionIsRTL() || publication.metadata.direction == PageProgressionDirection.rtl) {
                     // The view has RTL layout
                     currentFragment?.webView?.let {
                         currentFragment.webView.progression = 0.0
@@ -333,7 +333,7 @@ open class R2EpubActivity : AppCompatActivity(), IR2Activity, IR2Selectable, IR2
         resourcePager.direction = publication.metadata.direction
 
         if (publication.cssStyle == PageProgressionDirection.rtl.name) {
-            resourcePager.direction = PageProgressionDirection.rtl.name
+            resourcePager.direction = PageProgressionDirection.rtl
         }
 
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2RTLViewPager.java
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2RTLViewPager.java
@@ -47,7 +47,7 @@ import java.util.HashMap;
  * modifications are kept internal to <code>RtlViewPager</code>.
  */
 public class R2RTLViewPager extends ViewPager {
-    public String direction = PageProgressionDirection.ltr.name();
+    public PageProgressionDirection direction = PageProgressionDirection.ltr;
     private int mLayoutDirection = ViewCompat.LAYOUT_DIRECTION_LTR;
     private HashMap<OnPageChangeListener, ReversingOnPageChangeListener> mPageChangeListeners = new HashMap<>();
 
@@ -62,7 +62,7 @@ public class R2RTLViewPager extends ViewPager {
     public void onRtlPropertiesChanged(int layoutDirection) {
         super.onRtlPropertiesChanged(layoutDirection);
         int viewCompatLayoutDirection = layoutDirection == View.LAYOUT_DIRECTION_RTL  ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR;
-        if (direction.equals(PageProgressionDirection.rtl.name())) {
+        if (direction.equals(PageProgressionDirection.rtl)) {
             viewCompatLayoutDirection = ViewCompat.LAYOUT_DIRECTION_RTL;
         }
         if (viewCompatLayoutDirection != mLayoutDirection) {


### PR DESCRIPTION
Move publicaton data from intent extras to global variable
    A real-sized Publication containing media overlays is too large to be passed from one activity to another as intent extras.
    Use instead a global variable named CURRENT_PUB in the navigator package.

