### PR TITLE
Removed allowBackup and supportsRtl from manifest.

### DIFF
--- a/r2-navigator/src/main/AndroidManifest.xml
+++ b/r2-navigator/src/main/AndroidManifest.xml
@@ -15,10 +15,7 @@
     <uses-permission android:name="android.permission.WRITE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
-    <application
-        android:allowBackup="false"
-        android:supportsRtl="true"
-        tools:replace="android:allowBackup">
+    <application>
 
         <activity
             android:name=".epub.R2EpubActivity"


### PR DESCRIPTION
This may result in a manifest merge error
requiring implementors to use an override like 'tools:replace'.