### PR TITLE
Fix crash when jumping to HTML ID fragments

### DIFF
--- a/r2-navigator/src/main/java/org/readium/r2/navigator/extensions/Locator.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/extensions/Locator.kt
@@ -1,0 +1,53 @@
+/*
+ * Module: r2-navigator-kotlin
+ * Developers: Mickaël Menu
+ *
+ * Copyright (c) 2020. Readium Foundation. All rights reserved.
+ * Use of this source code is governed by a BSD-style license which is detailed in the
+ * LICENSE file present in the project repository where this source code is maintained.
+ */
+
+package org.readium.r2.navigator.extensions
+
+import org.readium.r2.shared.publication.Locator
+import java.util.*
+
+// FIXME: This should be in r2-shared once this public API is specified.
+
+// Reference: https://www.w3.org/TR/fragid-best-practices
+
+/**
+ * All named parameters found in the fragments, such as `p=5`.
+ */
+internal val Locator.Locations.fragmentParameters: Map<String, String> get() =
+    fragments
+        // Concatenates fragments together, after dropping any #
+        .map { it.removePrefix("#") }
+        .joinToString(separator = "&")
+        // Splits parameters
+        .split("&")
+        .filter { !it.startsWith("=") }
+        .map { it.split("=") }
+        // Only keep named parameters
+        .filter { it.size == 2 }
+        .associate { it[0].trim().toLowerCase(Locale.ROOT) to it[1].trim() }
+
+/**
+ * HTML ID fragment identifier.
+ */
+internal val Locator.Locations.htmlId: String? get() {
+    // The HTML 5 specification (used for WebPub) allows any character in an HTML ID, except
+    // spaces. This is an issue to differentiate with named parameters, so we ignore any
+    // ID containing `=`.
+    val id = fragments.firstOrNull { !it.isBlank() && !it.contains("=") }
+        ?: fragmentParameters["id"]
+        ?: fragmentParameters["name"]
+
+    return id?.removePrefix("#")
+}
+
+/**
+ * Page fragment identifier, used for example in PDF.
+ */
+internal val Locator.Locations.page: Int? get() =
+    fragmentParameters["page"]?.toIntOrNull()

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -29,6 +29,7 @@ import androidx.fragment.app.Fragment
 import androidx.webkit.WebViewClientCompat
 import org.readium.r2.navigator.*
 import org.readium.r2.navigator.epub.R2EpubActivity
+import org.readium.r2.navigator.extensions.htmlId
 import org.readium.r2.shared.APPEARANCE_REF
 import org.readium.r2.shared.SCROLL_REF
 import org.readium.r2.shared.publication.Locator
@@ -230,30 +231,12 @@ class R2EpubPageFragment : Fragment() {
         }
 
 
-        val locations = (webView.navigator as? R2EpubActivity)?.pendingLocator?.locations
-
-
-        locations?.fragments?.firstOrNull()?.let { fragment ->
-
-            val fragments = fragment.split(",").associate {
-                val (left, right) = it.split("=")
-                left to right.toInt()
-            }
-//            val id = fragments.getValue("id")
-            if (fragments.isEmpty()) {
-                var anchor = fragment
-                if (!anchor.startsWith("#")) {
-                    anchor = "#$anchor"
-                }
-                val href = resourceUrl + anchor
-                webView.loadUrl(href)
-            } else {
-                webView.loadUrl(resourceUrl)
-            }
-        } ?: run {
+        val id = (webView.navigator as? R2EpubActivity)?.pendingLocator?.locations?.htmlId
+        if (id != null) {
+            webView.loadUrl("$resourceUrl#$id")
+        } else {
             webView.loadUrl(resourceUrl)
         }
-
 
         return v
     }


### PR DESCRIPTION
The splitting code failed when passing an HTML ID fragment, which doesn't contain a `=`. This broke jumping to ToC item with IDs.