### PR TITLE
Fix crash when opening a publication with a space in its filename

### DIFF
--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
@@ -20,6 +20,7 @@ import android.util.DisplayMetrics
 import android.view.ActionMode
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import androidx.viewpager.widget.ViewPager
 import kotlinx.coroutines.*
 import org.json.JSONException
@@ -37,7 +38,6 @@ import org.readium.r2.shared.getAbsolute
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.presentation.presentation
-import java.net.URI
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.ceil
 
@@ -254,8 +254,8 @@ open class R2EpubActivity : AppCompatActivity(), IR2Activity, IR2Selectable, IR2
         var resourceIndexDouble = 0
 
         for ((resourceIndexSingle, spineItem) in publication.readingOrder.withIndex()) {
-            val uri: String = if (URI(publicationPath).isAbsolute) {
-                if (URI(spineItem.href).isAbsolute) {
+            val uri: String = if (publicationPath.toUri().isAbsolute) {
+                if (spineItem.href.toUri().isAbsolute) {
                     spineItem.href
                 } else {
                     getAbsolute(spineItem.href, publicationPath)


### PR DESCRIPTION
`URI(publicationPath)` crashed when the path contained a non percent-encoded space.

`android.net.Uri` should be preferred over `java.net.URI` when URL validity is not necessary, because it is more forgiving of invalid URI syntax.