### PR TITLE
Improve PDF navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
   * At the moment, highlights and TTS are not yet supported in the new EPUB navigator `Fragment`.
   * [This is now the recommended way to integrate Readium](https://github.com/readium/r2-navigator-kotlin/issues/115) in your applications.
 
+### Changed
+
+* Improvements in the PDF navigator:
+  * The navigator doesn't require PDF publications to be served from an HTTP server anymore. A side effect is that the navigator is now able to open larger PDF files.
+  * `PdfNavigatorFragment.Listener::onResourceLoadFailed()` can be used to report fatal errors to the user, such as when trying to open a PDF document that is too large for the available memory.
+  * A dedicated `PdfNavigatorFragment.Factory` was added, which deprecates the use of `NavigatorFragmentFactory`.
 
 ## [2.0.0-alpha.1]
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/NavigatorFragmentFactory.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/NavigatorFragmentFactory.kt
@@ -42,8 +42,7 @@ class NavigatorFragmentFactory(
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment =
         when (className) {
             PdfNavigatorFragment::class.java.name -> {
-                val baseUrl = baseUrl ?: throw IllegalArgumentException("[baseUrl] is required for the [PdfNavigatorFragment]")
-                PdfNavigatorFragment(publication, baseUrl, initialLocator, listener)
+                throw IllegalArgumentException("Use [PdfNavigatorFragment.Factory] to create a [PdfNavigatorFragment]")
             }
 
             EpubNavigatorFragment::class.java.name -> {

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
@@ -112,9 +112,14 @@ class PdfNavigatorFragment internal constructor(
         } else {
             lifecycleScope.launch {
                 try {
-                    val bytes = publication.get(link).read().getOrThrow()
-
-                    pdfView.fromBytes(bytes)
+                    pdfView
+                        .run {
+                            publication.get(link).use { resource ->
+                                val file = resource.file
+                                if (file != null) fromFile(file)
+                                else fromBytes(resource.read().getOrThrow())
+                            }
+                        }
                         .spacing(10)
                         // Customization of [PDFView] is done before setting the listeners,
                         // to avoid overriding them in reading apps, which would break the

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/util/SingleFragmentFactory.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/util/SingleFragmentFactory.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.navigator.util
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import java.lang.IllegalArgumentException
+
+/**
+ * A simple [FragmentFactory] creating a single [Fragment] type.
+ */
+abstract class SingleFragmentFactory<T : Fragment> : FragmentFactory() {
+
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        val fragment = instantiate()
+        val fragmentClass = fragment::class.java
+
+        return when (className) {
+            fragmentClass.name -> fragment
+
+            else -> throw Fragment.InstantiationException(
+                "[${this::class.simpleName}] can only be used to instantiate a [${fragmentClass.simpleName}]",
+                IllegalArgumentException("Expected ${fragmentClass.simpleName} as the class name")
+            )
+        }
+    }
+
+    abstract fun instantiate(): T
+
+}


### PR DESCRIPTION
* The navigator doesn't require PDF publications to be served from an HTTP server anymore. A side effect is that the navigator is now able to open larger PDF files.
* `PdfNavigatorFragment.Listener::onResourceLoadFailed()` can be used to report fatal errors to the user, such as when trying to open a PDF document that is too large for the available memory.
* A dedicated `PdfNavigatorFragment.Factory` was added, which deprecates the use of `NavigatorFragmentFactory`.