### PR TITLE
Split NavigatorFragmentFactory into one Factory per Navigator Fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
   * At the moment, highlights and TTS are not yet supported in the new EPUB navigator `Fragment`.
   * [This is now the recommended way to integrate Readium](https://github.com/readium/r2-navigator-kotlin/issues/115) in your applications.
 
+### Changed
+
+* Improvements in the PDF navigator:
+  * The navigator doesn't require PDF publications to be served from an HTTP server anymore. A side effect is that the navigator is now able to open larger PDF files.
+  * `PdfNavigatorFragment.Listener::onResourceLoadFailed()` can be used to report fatal errors to the user, such as when trying to open a PDF document that is too large for the available memory.
+  * A dedicated `PdfNavigatorFragment.Factory` was added, which deprecates the use of `NavigatorFragmentFactory`.
 
 ## [2.0.0-alpha.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 * (*Experimental*) New `Fragment` implementations as an alternative to the legacy `Activity` ones (contributed by [@johanpoirier](https://github.com/readium/r2-navigator-kotlin/pull/148)).
   * The fragments are chromeless, to let you customize the reading UX.
-  * Use the new `NavigatorFragmentFactory` to help build the fragments, as showcased in `R2PdfActivity`.
+  * To create the fragments use the matching factory such as `EpubNavigatorFragment.Factory`, as showcased in `R2EpubActivity`.
   * At the moment, highlights and TTS are not yet supported in the new EPUB navigator `Fragment`.
   * [This is now the recommended way to integrate Readium](https://github.com/readium/r2-navigator-kotlin/issues/115) in your applications.
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/NavigatorFragmentFactory.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/NavigatorFragmentFactory.kt
@@ -9,14 +9,7 @@
 
 package org.readium.r2.navigator
 
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
-import org.readium.r2.navigator.cbz.ImageNavigatorFragment
-import org.readium.r2.navigator.epub.EpubNavigatorFragment
-import org.readium.r2.navigator.pager.R2CbzPageFragment
-import org.readium.r2.navigator.pdf.PdfNavigatorFragment
-import org.readium.r2.shared.FragmentNavigator
-import org.readium.r2.shared.PdfSupport
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 
@@ -30,33 +23,10 @@ import org.readium.r2.shared.publication.Publication
  *        Can be used to restore the last reading location.
  * @param listener Optional listener to implement to observe events, such as user taps.
  */
-@FragmentNavigator
+@Deprecated("Each [Fragment] has now its own factory, such as [EpubNavigatorFragment.Factory]. To use a single [Activity] with several navigator fragments, you can compose the factories with [CompositeFragmentFactory].", level = DeprecationLevel.ERROR)
 class NavigatorFragmentFactory(
     private val publication: Publication,
     private val baseUrl: String? = null,
     private val initialLocator: Locator? = null,
     private val listener: Navigator.Listener? = null
-) : FragmentFactory() {
-
-    @OptIn(PdfSupport::class)
-    override fun instantiate(classLoader: ClassLoader, className: String): Fragment =
-        when (className) {
-            PdfNavigatorFragment::class.java.name -> {
-                throw IllegalArgumentException("Use [PdfNavigatorFragment.Factory] to create a [PdfNavigatorFragment]")
-            }
-
-            EpubNavigatorFragment::class.java.name -> {
-                val baseUrl = baseUrl ?: throw IllegalArgumentException("[baseUrl] is required for the [EpubNavigatorFragment]")
-                EpubNavigatorFragment(publication, baseUrl, initialLocator, listener)
-            }
-
-            ImageNavigatorFragment::class.java.name ->
-                ImageNavigatorFragment(publication, initialLocator, listener)
-
-            R2CbzPageFragment::class.java.name ->
-                R2CbzPageFragment(publication)
-
-            else -> super.instantiate(classLoader, className)
-        }
-
-}
+) : FragmentFactory()

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/NavigatorFragmentFactory.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/NavigatorFragmentFactory.kt
@@ -42,8 +42,7 @@ class NavigatorFragmentFactory(
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment =
         when (className) {
             PdfNavigatorFragment::class.java.name -> {
-                val baseUrl = baseUrl ?: throw IllegalArgumentException("[baseUrl] is required for the [PdfNavigatorFragment]")
-                PdfNavigatorFragment(publication, baseUrl, initialLocator, listener)
+                throw IllegalArgumentException("Use [PdfNavigatorFragment.Factory] to create a [PdfNavigatorFragment]")
             }
 
             EpubNavigatorFragment::class.java.name -> {

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/ImageNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/ImageNavigatorFragment.kt
@@ -14,26 +14,58 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentFactory
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.viewpager.widget.ViewPager
 import kotlinx.coroutines.*
-import org.readium.r2.navigator.Navigator
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.VisualNavigator
 import org.readium.r2.navigator.extensions.layoutDirectionIsRTL
+import org.readium.r2.navigator.pager.R2CbzPageFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
 import org.readium.r2.navigator.pager.R2ViewPager
-import org.readium.r2.shared.FragmentNavigator
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.services.positions
 
-@FragmentNavigator
-class ImageNavigatorFragment(
+/**
+ * Navigator for bitmap-based publications, such as CBZ.
+ */
+class ImageNavigatorFragment private constructor(
     internal val publication: Publication,
     private val initialLocator: Locator? = null,
-    internal val listener: Navigator.Listener? = null
+    internal val listener: Listener? = null
 ) : Fragment(), CoroutineScope by MainScope(), VisualNavigator {
+
+    interface Listener : VisualNavigator.Listener
+
+    /**
+     * Factory for [ImageNavigatorFragment].
+     *
+     * @param publication Bitmap-based publication to render in the navigator.
+     * @param initialLocator The first location which should be visible when rendering the
+     *        publication. Can be used to restore the last reading location.
+     * @param listener Optional listener to implement to observe events, such as user taps.
+     */
+    class Factory(
+        private val publication: Publication,
+        private val initialLocator: Locator? = null,
+        private val listener: Listener? = null
+    ) : FragmentFactory() {
+
+        override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+            return when (className) {
+                ImageNavigatorFragment::class.java.name ->
+                    ImageNavigatorFragment(publication, initialLocator, listener)
+
+                R2CbzPageFragment::class.java.name ->
+                    R2CbzPageFragment(publication)
+
+                else -> super.instantiate(classLoader, className)
+            }
+        }
+
+    }
 
     internal lateinit var positions: List<Locator>
     internal lateinit var resourcePager: R2ViewPager

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/R2CbzActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/R2CbzActivity.kt
@@ -16,31 +16,19 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentFactory
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import androidx.viewpager.widget.ViewPager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.readium.r2.navigator.*
-import org.readium.r2.navigator.epub.EpubNavigatorFragment
-import org.readium.r2.navigator.extensions.layoutDirectionIsRTL
-import org.readium.r2.navigator.pager.R2CbzPageFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
 import org.readium.r2.navigator.pager.R2ViewPager
-import org.readium.r2.shared.FragmentNavigator
-import org.readium.r2.shared.extensions.destroyPublication
 import org.readium.r2.shared.extensions.getPublication
 import org.readium.r2.shared.publication.*
-import org.readium.r2.shared.publication.services.positions
 import kotlin.coroutines.CoroutineContext
 
-@OptIn(FragmentNavigator::class)
-open class R2CbzActivity : AppCompatActivity(), CoroutineScope, IR2Activity, VisualNavigator, VisualNavigator.Listener {
+open class R2CbzActivity : AppCompatActivity(), CoroutineScope, IR2Activity, VisualNavigator, ImageNavigatorFragment.Listener {
 
     private val navigatorFragment: ImageNavigatorFragment
         get() = supportFragmentManager.findFragmentById(R.id.image_navigator) as ImageNavigatorFragment
@@ -104,7 +92,7 @@ open class R2CbzActivity : AppCompatActivity(), CoroutineScope, IR2Activity, Vis
 
         val initialLocator = intent.getParcelableExtra("locator") as? Locator
 
-        supportFragmentManager.fragmentFactory = NavigatorFragmentFactory(publication, initialLocator = initialLocator, listener = this)
+        supportFragmentManager.fragmentFactory = ImageNavigatorFragment.Factory(publication, initialLocator = initialLocator, listener = this)
 
         super.onCreate(savedInstanceState)
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/R2CbzActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/R2CbzActivity.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.readium.r2.navigator.*
+import org.readium.r2.navigator.image.ImageNavigatorFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
 import org.readium.r2.navigator.pager.R2ViewPager
 import org.readium.r2.shared.extensions.getPublication

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -15,6 +15,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentFactory
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.viewpager.widget.ViewPager
@@ -26,6 +27,8 @@ import org.readium.r2.navigator.extensions.positionsByResource
 import org.readium.r2.navigator.pager.R2EpubPageFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
 import org.readium.r2.navigator.pager.R2ViewPager
+import org.readium.r2.navigator.pdf.PdfNavigatorFragment
+import org.readium.r2.navigator.util.SingleFragmentFactory
 import org.readium.r2.shared.*
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.Link
@@ -37,14 +40,38 @@ import org.readium.r2.shared.publication.services.positions
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.ceil
 
-@FragmentNavigator
-class EpubNavigatorFragment(
+/**
+ * Navigator for EPUB publications.
+ */
+class EpubNavigatorFragment private constructor(
     internal val publication: Publication,
     private val baseUrl: String,
     private val initialLocator: Locator? = null,
-    internal val listener: Navigator.Listener? = null
+    internal val listener: Listener? = null
 ): Fragment(), CoroutineScope by MainScope(), VisualNavigator, R2BasicWebView.Listener {
 
+    interface Listener: VisualNavigator.Listener
+
+    /**
+     * Factory for [EpubNavigatorFragment].
+     *
+     * @param publication EPUB publication to render in the navigator.
+     * @param baseUrl A base URL where this publication is served from.
+     * @param initialLocator The first location which should be visible when rendering the
+     *        publication. Can be used to restore the last reading location.
+     * @param listener Optional listener to implement to observe events, such as user taps.
+     */
+    class Factory(
+        private val publication: Publication,
+        private val baseUrl: String,
+        private val initialLocator: Locator? = null,
+        private val listener: Listener? = null
+    ) : SingleFragmentFactory<EpubNavigatorFragment>() {
+
+        override fun instantiate(): EpubNavigatorFragment =
+            EpubNavigatorFragment(publication, baseUrl, initialLocator, listener)
+
+    }
 
     internal lateinit var positions: List<Locator>
     lateinit var resourcePager: R2ViewPager

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
@@ -31,7 +31,6 @@ import org.readium.r2.navigator.*
 import org.readium.r2.navigator.pager.R2EpubPageFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
 import org.readium.r2.navigator.pager.R2ViewPager
-import org.readium.r2.shared.FragmentNavigator
 import org.readium.r2.shared.extensions.getPublication
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
@@ -39,8 +38,7 @@ import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression
 import kotlin.coroutines.CoroutineContext
 
-@OptIn(FragmentNavigator::class)
-open class R2EpubActivity: AppCompatActivity(), IR2Activity, IR2Selectable, IR2Highlightable, IR2TTS, CoroutineScope, VisualNavigator, VisualNavigator.Listener {
+open class R2EpubActivity: AppCompatActivity(), IR2Activity, IR2Selectable, IR2Highlightable, IR2TTS, CoroutineScope, VisualNavigator, EpubNavigatorFragment.Listener {
 
     /**
      * Context of this scope.
@@ -89,7 +87,7 @@ open class R2EpubActivity: AppCompatActivity(), IR2Activity, IR2Selectable, IR2H
 
         val initialLocator = intent.getParcelableExtra("locator") as? Locator
 
-        supportFragmentManager.fragmentFactory = NavigatorFragmentFactory(publication, baseUrl = baseUrl, initialLocator = initialLocator, listener = this)
+        supportFragmentManager.fragmentFactory = EpubNavigatorFragment.Factory(publication, baseUrl = baseUrl, initialLocator = initialLocator, listener = this)
 
         super.onCreate(savedInstanceState)
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
@@ -4,7 +4,7 @@
  * available in the top-level LICENSE file of the project.
  */
 
-package org.readium.r2.navigator.cbz
+package org.readium.r2.navigator.image
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -29,13 +29,11 @@ import org.readium.r2.navigator.R2BasicWebView
 import org.readium.r2.navigator.R2WebView
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.extensions.htmlId
-import org.readium.r2.shared.FragmentNavigator
 import org.readium.r2.shared.SCROLL_REF
 import org.readium.r2.shared.publication.Locator
 import java.io.IOException
 import java.io.InputStream
 
-@OptIn(FragmentNavigator::class)
 class R2EpubPageFragment : Fragment() {
 
     private val resourceUrl: String?

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
@@ -25,10 +25,7 @@ import org.readium.r2.navigator.R2BasicWebView
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.epub.fxl.R2FXLLayout
 import org.readium.r2.navigator.epub.fxl.R2FXLOnDoubleTapListener
-import org.readium.r2.shared.FragmentNavigator
 
-
-@OptIn(FragmentNavigator::class)
 class R2FXLPageFragment : Fragment() {
 
     private val firstResourceUrl: String?

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
@@ -25,14 +25,15 @@ import kotlinx.coroutines.runBlocking
 import org.readium.r2.navigator.VisualNavigator
 import org.readium.r2.navigator.extensions.page
 import org.readium.r2.navigator.util.SingleFragmentFactory
-import org.readium.r2.shared.FragmentNavigator
 import org.readium.r2.shared.PdfSupport
 import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.services.positionsByReadingOrder
 import timber.log.Timber
 
-@PdfSupport @FragmentNavigator
+/**
+ * Navigator for PDF publications.
+ */
 class PdfNavigatorFragment internal constructor(
     private val publication: Publication,
     private val initialLocator: Locator? = null,

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/R2PdfActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/R2PdfActivity.kt
@@ -10,23 +10,17 @@
 package org.readium.r2.navigator.pdf
 
 import android.app.Activity
-import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import org.readium.r2.navigator.Navigator
-import org.readium.r2.navigator.NavigatorFragmentFactory
 import org.readium.r2.navigator.R
-import org.readium.r2.shared.FragmentNavigator
 import org.readium.r2.shared.PdfSupport
 import org.readium.r2.shared.extensions.getPublication
-import org.readium.r2.shared.extensions.putPublication
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 
 @PdfSupport
-@OptIn(FragmentNavigator::class)
 abstract class R2PdfActivity : AppCompatActivity(), PdfNavigatorFragment.Listener {
 
     protected lateinit var publication: Publication

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/util/CompositeFragmentFactory.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/util/CompositeFragmentFactory.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.navigator.util
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import org.readium.r2.shared.extensions.tryOrNull
+
+/**
+ * A [FragmentFactory] which will iterate over a provided list of [factories] until finding one
+ * instantiating successfully the requested [Fragment].
+ *
+ * ```
+ * supportFragmentManager.fragmentFactory = CompositeFragmentFactory(
+ *     EpubNavigatorFragment.Factory(publication, baseUrl, initialLocator, this),
+ *     PdfNavigatorFragment.Factory(publication, initialLocator, this)
+ * )
+ * ```
+ */
+class CompositeFragmentFactory(private val factories: List<FragmentFactory>) : FragmentFactory() {
+
+    constructor(vararg factories: FragmentFactory) : this(factories.toList())
+
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        for (factory in factories) {
+            tryOrNull { factory.instantiate(classLoader, className) }
+                ?.let { return it }
+        }
+
+        return super.instantiate(classLoader, className)
+    }
+
+}

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/util/SingleFragmentFactory.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/util/SingleFragmentFactory.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.navigator.util
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import java.lang.IllegalArgumentException
+
+/**
+ * A simple [FragmentFactory] creating a single [Fragment] type.
+ */
+abstract class SingleFragmentFactory<T : Fragment> : FragmentFactory() {
+
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        val fragment = instantiate()
+        val fragmentClass = fragment::class.java
+
+        return when (className) {
+            fragmentClass.name -> fragment
+
+            else -> throw Fragment.InstantiationException(
+                "[${this::class.simpleName}] can only be used to instantiate a [${fragmentClass.simpleName}]",
+                IllegalArgumentException("Expected ${fragmentClass.simpleName} as the class name")
+            )
+        }
+    }
+
+    abstract fun instantiate(): T
+
+}

--- a/r2-navigator/src/main/res/layout/activity_r2_image.xml
+++ b/r2-navigator/src/main/res/layout/activity_r2_image.xml
@@ -6,7 +6,7 @@
     <fragment
         android:id="@+id/image_navigator"
         android:tag="@string/image_navigator_tag"
-        android:name="org.readium.r2.navigator.cbz.ImageNavigatorFragment"
+        android:name="org.readium.r2.navigator.image.ImageNavigatorFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />


### PR DESCRIPTION
https://github.com/readium/r2-navigator-kotlin/pull/162 needs to be merged first, [here's the real diff](https://github.com/readium/r2-navigator-kotlin/compare/fix/oom...fix/fragment-factories).

Adds one `FragmentFactory` per navigator `Fragment`, to have type safe arguments and improved encapsulation.