### PR TITLE
Deprecate ContentLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
-**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
+**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with
+caution.
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
 * Upgraded to Kotlin 1.4.10.
+
+### Fixed
+
+* EPUBs declaring multiple languages were laid out from right to left if the first language had an RTL reading
+progression. Now if no reading progression is set, the `effectiveReadingProgression` will be LTR.
 
 
 ## [2.0.0-alpha.2]

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -149,7 +149,7 @@ class EpubNavigatorFragment private constructor(
         }
         resourcePager.adapter = adapter
 
-        resourcePager.direction = publication.contentLayout.readingProgression
+        resourcePager.direction = publication.metadata.effectiveReadingProgression
 
         if (publication.cssStyle == ReadingProgression.RTL.value) {
             resourcePager.direction = ReadingProgression.RTL
@@ -333,7 +333,7 @@ class EpubNavigatorFragment private constructor(
 
                 resourcePager.setCurrentItem(resourcePager.currentItem + 1, animated)
 
-                if (currentFragment?.activity?.layoutDirectionIsRTL() ?: publication.contentLayout.readingProgression == ReadingProgression.RTL) {
+                if (currentFragment?.activity?.layoutDirectionIsRTL() ?: publication.metadata.effectiveReadingProgression == ReadingProgression.RTL) {
                     // The view has RTL layout
                     currentFragment?.webView?.apply {
                         progression = 1.0
@@ -357,7 +357,7 @@ class EpubNavigatorFragment private constructor(
 
                 resourcePager.setCurrentItem(resourcePager.currentItem - 1, animated)
 
-                if (currentFragment?.activity?.layoutDirectionIsRTL() ?: publication.contentLayout.readingProgression == ReadingProgression.RTL) {
+                if (currentFragment?.activity?.layoutDirectionIsRTL() ?: publication.metadata.effectiveReadingProgression == ReadingProgression.RTL) {
                     // The view has RTL layout
                     currentFragment?.webView?.apply {
                         progression = 0.0
@@ -382,7 +382,7 @@ class EpubNavigatorFragment private constructor(
         r2PagerAdapter.mFragments.get(r2PagerAdapter.getItemId(resourcePager.currentItem)) as? R2EpubPageFragment
 
     override val readingProgression: ReadingProgression
-        get() = publication.contentLayout.readingProgression
+        get() = publication.metadata.effectiveReadingProgression
 
     override val currentLocator: StateFlow<Locator> get() = _currentLocator
     private val _currentLocator = MutableStateFlow(initialLocator ?: publication.readingOrder.first().toLocator())

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
@@ -151,7 +151,7 @@ class ImageNavigatorFragment private constructor(
     }
 
     override val readingProgression: ReadingProgression
-        get() = publication.contentLayout.readingProgression
+        get() = publication.metadata.effectiveReadingProgression
 
     override fun go(locator: Locator, animated: Boolean, completion: () -> Unit): Boolean {
         val resourceIndex = publication.readingOrder.indexOfFirstWithHref(locator.href)


### PR DESCRIPTION
* EPUBs declaring multiple languages were laid out from right to left if the first language had an RTL reading
progression. Now if no reading progression is set, the `effectiveReadingProgression` will be LTR.