### PR TITLE
Support for display cutouts and EPUB vertical padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * Support for [display cutouts](https://developer.android.com/guide/topics/display-cutout) (screen notches).
+    * **IMPORTANT**: You need to remove any `setPadding()` statement from your app in `UserSettings.kt`, if you copied it from the test app.
     * If you embed a navigator fragment (e.g. `EpubNavigatorFragment`) yourself, you need to opt-in by [specifying the `layoutInDisplayCutoutMode`](https://developer.android.com/guide/topics/display-cutout#choose_how_your_app_handles_cutout_areas) of the host `Activity`.
-    * `R2EpubActivity` and `R2CbzActivity` automatically applies `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` to its window's `layoutInDisplayCutoutMode`.
-* Customize EPUB vertical margins by overriding the `r2.navigator.epub.vertical_padding` dimension.
+    * `R2EpubActivity` and `R2CbzActivity` automatically apply `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` to their window's `layoutInDisplayCutoutMode`.
+    * `PdfNavigatorFragment` is not yet compatible with display cutouts, because of limitations from the underlying PDF viewer.
+* Customize EPUB vertical padding by overriding the `r2.navigator.epub.vertical_padding` dimension.
     * Follow [Android's convention for alternative resources](https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources) to specify different paddings for landscape (`values-land`) or large screens.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ caution.
 
 ## [Unreleased]
 
+### Added
+
+* Support for [display cutouts](https://developer.android.com/guide/topics/display-cutout) (screen notches).
+    * If you embed `EpubNavigatorFragment` yourself, you need to opt-in by [specifying the `layoutInDisplayCutoutMode`](https://developer.android.com/guide/topics/display-cutout#choose_how_your_app_handles_cutout_areas) of the host `Activity`.
+    * `R2EpubActivity` automatically applies `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` to its window's `layoutInDisplayCutoutMode`.
+* Customize EPUB vertical margins by overriding the `r2.navigator.epub.vertical_padding` dimension.
+    * Follow [Android's convention for alternative resources](https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources) to specify different paddings for landscape (`values-land`) or large screens.
+
 ### Changed
 
 * Upgraded to Kotlin 1.4.10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with
-caution.
+**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
 ## [Unreleased]
 
 ### Added
 
 * Support for [display cutouts](https://developer.android.com/guide/topics/display-cutout) (screen notches).
-    * If you embed `EpubNavigatorFragment` yourself, you need to opt-in by [specifying the `layoutInDisplayCutoutMode`](https://developer.android.com/guide/topics/display-cutout#choose_how_your_app_handles_cutout_areas) of the host `Activity`.
-    * `R2EpubActivity` automatically applies `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` to its window's `layoutInDisplayCutoutMode`.
+    * If you embed a navigator fragment (e.g. `EpubNavigatorFragment`) yourself, you need to opt-in by [specifying the `layoutInDisplayCutoutMode`](https://developer.android.com/guide/topics/display-cutout#choose_how_your_app_handles_cutout_areas) of the host `Activity`.
+    * `R2EpubActivity` and `R2CbzActivity` automatically applies `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` to its window's `layoutInDisplayCutoutMode`.
 * Customize EPUB vertical margins by overriding the `r2.navigator.epub.vertical_padding` dimension.
     * Follow [Android's convention for alternative resources](https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources) to specify different paddings for landscape (`values-land`) or large screens.
 

--- a/r2-navigator/src/main/assets/readium/scripts/utils.js
+++ b/r2-navigator/src/main/assets/readium/scripts/utils.js
@@ -48,7 +48,7 @@ var readium = (function() {
             return;
         }
 
-        element.scrollIntoView();
+        element.scrollIntoView({inline: "center"});
         snapCurrentOffset()
     }
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -24,6 +24,9 @@ import android.widget.PopupWindow
 import android.widget.TextView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
@@ -45,8 +48,9 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
     var overrideUrlLoading = true
     var resourceUrl: String? = null
 
-    var scrollMode: Boolean = false
-      private set
+    internal val scrollModeFlow = MutableStateFlow(false)
+
+    val scrollMode: Boolean get() = scrollModeFlow.value
 
     var callback: OnOverScrolledCallback? = null
 
@@ -281,7 +285,7 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
 
     fun setScrollMode(scrollMode: Boolean) {
         runJavaScript("setScrollMode($scrollMode)")
-        this.scrollMode = scrollMode
+        scrollModeFlow.value = scrollMode
     }
 
     fun setProperty(key: String, value: String) {

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/R2WebView.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/R2WebView.kt
@@ -722,7 +722,6 @@ class R2WebView(context: Context, attrs: AttributeSet) : R2BasicWebView(context,
                     val x = ev.getX(activePointerIndex)
                     val y = ev.getY(activePointerIndex)
 
-                    val scrollMode = preferences?.getBoolean(SCROLL_REF, false) ?: false
                     if (scrollMode) {
                         val totalDelta = (y - mInitialMotionY).toInt()
                         if (abs(totalDelta) < 200) {

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/R2CbzActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/cbz/R2CbzActivity.kt
@@ -15,6 +15,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.asLiveData
@@ -107,6 +108,11 @@ open class R2CbzActivity : AppCompatActivity(), CoroutineScope, IR2Activity, Vis
             @Suppress("DEPRECATION")
             navigatorDelegate?.locationDidChange(this, locator)
         })
+
+        // Add support for display cutout.
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        }
     }
 
     override fun finish() {

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.util.DisplayMetrics
 import android.view.ActionMode
 import android.view.View
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -96,6 +97,11 @@ open class R2EpubActivity: AppCompatActivity(), IR2Activity, IR2Selectable, IR2H
         resourcePager = navigatorFragment.resourcePager
 
         title = null
+
+        // Add support for display cutout.
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        }
     }
 
     override fun finish() {

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
@@ -16,9 +16,12 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentFactory
 import androidx.viewpager.widget.ViewPager
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.VisualNavigator
 import org.readium.r2.navigator.extensions.layoutDirectionIsRTL

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2CbzPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2CbzPageFragment.kt
@@ -14,11 +14,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.ImageView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.readium.r2.navigator.R
+import org.readium.r2.shared.SCROLL_REF
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
 import kotlin.coroutines.CoroutineContext
@@ -31,12 +38,18 @@ class R2CbzPageFragment(private val publication: Publication)
         get() = Dispatchers.Main
 
     private val link: Link
-        get() = requireArguments().getParcelable<Link>("link")!!
+        get() = requireArguments().getParcelable("link")!!
+
+    private var windowInsets: WindowInsetsCompat = WindowInsetsCompat.CONSUMED
+    private lateinit var containerView: View
+    private lateinit var imageView: ImageView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 
-        val view = inflater.inflate(R.layout.viewpager_fragment_cbz, container, false)
-        val imageView = view.findViewById<ImageView>(R.id.imageView)
+        containerView = inflater.inflate(R.layout.viewpager_fragment_cbz, container, false)
+        imageView = containerView.findViewById(R.id.imageView)
+
+        setupPadding()
 
        launch {
            publication.get(link)
@@ -46,7 +59,41 @@ class R2CbzPageFragment(private val publication: Publication)
                ?.let { imageView.setImageBitmap(it) }
        }
 
-       return view
+       return containerView
+    }
+
+    private fun setupPadding() {
+        updatePadding()
+
+        // Update padding when the window insets change, for example when the navigation and status
+        // bars are toggled.
+        ViewCompat.setOnApplyWindowInsetsListener(containerView) { _, insets ->
+            windowInsets = insets
+            updatePadding()
+            insets
+        }
+    }
+
+    private fun updatePadding() {
+        val activity = activity ?: return
+        if (!viewLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
+            return
+        }
+
+        var top = 0
+        var bottom = 0
+
+        // Add additional padding to take into account the display cutout, if needed.
+        if (
+            android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P &&
+            activity.window.attributes.layoutInDisplayCutoutMode != WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+        ) {
+            val displayCutoutInsets = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout())
+            top += displayCutoutInsets.top
+            bottom += displayCutoutInsets.bottom
+        }
+
+        imageView.setPadding(0, top, 0, bottom)
     }
 
 }

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -258,27 +258,27 @@ class R2EpubPageFragment : Fragment() {
             return
         }
 
-        val scrollMode = preferences.getBoolean(SCROLL_REF, false)
-        if (scrollMode) {
-            containerView.setPadding(0, 0, 0, 0)
+        var top = 0
+        var bottom = 0
 
-        } else {
-            val margin = resources.getDimension(R.dimen.r2_navigator_epub_vertical_padding).toInt()
-            var top = margin
-            var bottom = margin
-
-            // Add additional padding to take into account the display cutout, if needed.
-            if (
-                android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P &&
-                activity.window.attributes.layoutInDisplayCutoutMode != WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
-            ) {
-                val displayCutoutInsets = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout())
-                top += displayCutoutInsets.top
-                bottom += displayCutoutInsets.bottom
-            }
-
-            containerView.setPadding(0, top, 0, bottom)
+        // Add additional padding to take into account the display cutout, if needed.
+        if (
+            android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P &&
+            activity.window.attributes.layoutInDisplayCutoutMode != WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+        ) {
+            val displayCutoutInsets = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout())
+            top += displayCutoutInsets.top
+            bottom += displayCutoutInsets.bottom
         }
+
+        val scrollMode = preferences.getBoolean(SCROLL_REF, false)
+        if (!scrollMode) {
+            val margin = resources.getDimension(R.dimen.r2_navigator_epub_vertical_padding).toInt()
+            top += margin
+            bottom += margin
+        }
+
+        containerView.setPadding(0, top, 0, bottom)
     }
 
     companion object {

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/R2PdfActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/R2PdfActivity.kt
@@ -11,6 +11,7 @@ package org.readium.r2.navigator.pdf
 
 import android.app.Activity
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.asLiveData
@@ -52,6 +53,11 @@ abstract class R2PdfActivity : AppCompatActivity(), PdfNavigatorFragment.Listene
 
             onCurrentLocatorChanged(locator)
         })
+
+        // Display cutouts are not compatible with the underlying `PdfNavigatorFragment` yet.
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+        }
     }
 
     override fun finish() {

--- a/r2-navigator/src/main/res/layout/viewpager_fragment_cbz.xml
+++ b/r2-navigator/src/main/res/layout/viewpager_fragment_cbz.xml
@@ -19,6 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scaleType="fitCenter"
+        android:cropToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/r2-navigator/src/main/res/layout/viewpager_fragment_epub.xml
+++ b/r2-navigator/src/main/res/layout/viewpager_fragment_epub.xml
@@ -8,7 +8,8 @@
   ~ LICENSE file present in the project repository where this source code is maintained.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -19,4 +20,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/r2-navigator/src/main/res/values-land/dimens.xml
+++ b/r2-navigator/src/main/res/values-land/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="r2.navigator.epub.vertical_padding">20dp</dimen>
+</resources>

--- a/r2-navigator/src/main/res/values/dimens.xml
+++ b/r2-navigator/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="r2.navigator.epub.vertical_padding">40dp</dimen>
+</resources>


### PR DESCRIPTION
* Support for [display cutouts](https://developer.android.com/guide/topics/display-cutout) (screen notches).
    * **IMPORTANT**: You need to remove any `setPadding()` statement from your app in `UserSettings.kt`, if you copied it from the test app. See https://github.com/readium/r2-testapp-kotlin/pull/371
    * If you embed a navigator fragment (e.g. `EpubNavigatorFragment`) yourself, you need to opt-in by [specifying the `layoutInDisplayCutoutMode`](https://developer.android.com/guide/topics/display-cutout#choose_how_your_app_handles_cutout_areas) of the host `Activity`.
    * `R2EpubActivity` and `R2CbzActivity` automatically apply `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` to their window's `layoutInDisplayCutoutMode`.
    * `PdfNavigatorFragment` is not yet compatible with display cutouts, because of limitations from the underlying PDF viewer.
* Customize EPUB vertical padding by overriding the `r2.navigator.epub.vertical_padding` dimension.
    * Follow [Android's convention for alternative resources](https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources) to specify different paddings for landscape (`values-land`) or large screens.

---

### EPUB scroll mode

Vertical padding is not yet available in EPUB scroll mode, and the display cutouts support is subpar. There is still some unresolved issue detailed in https://github.com/readium/readium-css/issues/98#issuecomment-730293660

However, the navigator now makes sure that the scrolled content doesn't get hidden behind the display cutout. The downsides is that the content is cropped around the safe area, until aforementioned issue is settled.

<img width="426" alt="Screenshot 2020-11-24 at 11 48 17" src="https://user-images.githubusercontent.com/58686775/100240801-46a52e00-2f33-11eb-9af7-4584f1ed7fcd.png">
