### PR TITLE
Disable text selection for protected publications

### DIFF
--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -35,6 +35,8 @@ import org.readium.r2.navigator.extensions.htmlId
 import org.readium.r2.shared.SCROLL_REF
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.ReadingProgression
+import org.readium.r2.shared.publication.services.isProtected
+import org.readium.r2.shared.publication.services.isRestricted
 import java.io.IOException
 import java.io.InputStream
 import kotlin.math.roundToInt
@@ -208,10 +210,14 @@ class R2EpubPageFragment : Fragment() {
             }
         }
 
-        webView.isHapticFeedbackEnabled = false
-        webView.isLongClickable = false
-        webView.setOnLongClickListener {
-            false
+        // Disable the text selection if the publication is protected.
+        // FIXME: This is a hack until proper LCP copy is implemented, see https://github.com/readium/r2-testapp-kotlin/issues/266
+        if (navigatorFragment.publication.isProtected) {
+            webView.isHapticFeedbackEnabled = false
+            webView.isLongClickable = false
+            webView.setOnLongClickListener {
+                true
+            }
         }
 
         resourceUrl?.let { webView.loadUrl(it) }

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
@@ -26,6 +26,7 @@ import org.readium.r2.navigator.R2BasicWebView
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.epub.fxl.R2FXLLayout
 import org.readium.r2.navigator.epub.fxl.R2FXLOnDoubleTapListener
+import org.readium.r2.shared.publication.services.isProtected
 
 class R2FXLPageFragment : Fragment() {
 
@@ -97,6 +98,8 @@ class R2FXLPageFragment : Fragment() {
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun setupWebView(webView: R2BasicWebView, resourceUrl: String?) {
+        val navigatorFragment = parentFragment as EpubNavigatorFragment
+
         webViews.add(webView)
         webView.navigator = parentFragment as Navigator
         webView.listener = parentFragment as R2BasicWebView.Listener
@@ -133,10 +136,15 @@ class R2FXLPageFragment : Fragment() {
             }
 
         }
-        webView.isHapticFeedbackEnabled = false
-        webView.isLongClickable = false
-        webView.setOnLongClickListener {
-            true
+
+        // Disable the text selection if the publication is protected.
+        // FIXME: This is a hack until proper LCP copy is implemented, see https://github.com/readium/r2-testapp-kotlin/issues/266
+        if (navigatorFragment.publication.isProtected) {
+            webView.isHapticFeedbackEnabled = false
+            webView.isLongClickable = false
+            webView.setOnLongClickListener {
+                true
+            }
         }
 
         resourceUrl?.let { webView.loadUrl(it) }


### PR DESCRIPTION
Disable text selection altogether if the publication is protected (with LCP or other). 

This is a hack until proper LCP copy is implemented, see https://github.com/readium/r2-testapp-kotlin/issues/266

Currently copy was unrestricted with LCP publications if an app didn't use the highlight feature. This is not apparent with highlighting because the standard popup is overridden and doesn't have the Copy option.

The downside at the moment is that highlighting is disabled with protected publication with this fix. This might be desirable or not, so we need to discuss this before merging this PR.


EDIT: It doesn't prevent keyboard selection on Chrome OS. This other PR addresses the problem: https://github.com/readium/r2-streamer-kotlin/pull/141
