### PR TITLE
Require baseUrl Intent extra for R2EpubActivity and R2AudiobookActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+* `R2EpubActivity` and `R2AudiobookActivity` require a new `baseUrl` `Intent` extra. You need to set it to the base URL returned by `Server.addPublication()` from the Streamer.
+
 ### Fixed
 
 * [#217](https://github.com/readium/r2-testapp-kotlin/issues/217) Interactive HTML elements are not bypassed anymore when handling touch gestures.

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/audiobook/R2AudiobookActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/audiobook/R2AudiobookActivity.kt
@@ -21,7 +21,7 @@ import org.readium.r2.navigator.IR2Activity
 import org.readium.r2.navigator.NavigatorDelegate
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.VisualNavigator
-import org.readium.r2.navigator.extensions.withLocalUrl
+import org.readium.r2.navigator.extensions.withBaseUrl
 import org.readium.r2.shared.extensions.getPublication
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.services.isRestricted
@@ -137,6 +137,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
 
         publicationPath = intent.getStringExtra("publicationPath") ?: throw Exception("publicationPath required")
         publicationFileName = intent.getStringExtra("publicationFileName") ?: throw Exception("publicationFileName required")
+        val baseUrl = intent.getStringExtra("baseUrl") ?: throw Exception("Intent extra `baseUrl` is required. Provide the URL returned by Server.addPublication()")
 
         publication = intent.getPublication(this)
         publicationIdentifier = publication.metadata.identifier ?: publication.metadata.title
@@ -145,8 +146,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
 
         title = null
 
-        val port = preferences.getString("$publicationIdentifier-publicationPort", 0.toString())!!.toInt()
-        val readingOrderOverHttp = publication.readingOrder.map { it.withLocalUrl(publicationFileName, port) }
+        val readingOrderOverHttp = publication.readingOrder.map { it.withBaseUrl(baseUrl) }
         mediaPlayer = R2MediaPlayer(readingOrderOverHttp, this)
 
         Handler().postDelayed({

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
@@ -90,9 +90,7 @@ open class R2EpubActivity: AppCompatActivity(), IR2Activity, IR2Selectable, IR2H
         publicationPath = intent.getStringExtra("publicationPath") ?: throw Exception("publicationPath required")
         publicationFileName = intent.getStringExtra("publicationFileName") ?: throw Exception("publicationFileName required")
         publicationIdentifier = publication.metadata.identifier ?: publication.metadata.title
-
-        val port = preferences.getString("$publicationIdentifier-publicationPort", 0.toString())!!.toInt()
-        val baseUrl = Publication.localBaseUrlOf(publicationFileName, port)
+        val baseUrl = intent.getStringExtra("baseUrl") ?: throw Exception("Intent extra `baseUrl` is required. Provide the URL returned by Server.addPublication()")
 
         val initialLocator = intent.getParcelableExtra("locator") as? Locator
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/extensions/Link.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/extensions/Link.kt
@@ -12,8 +12,7 @@ package org.readium.r2.navigator.extensions
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
 
-internal fun Link.withLocalUrl(filename: String, port: Int): Link {
-    val baseUrl = Publication.localBaseUrlOf(filename, port)
+internal fun Link.withBaseUrl(baseUrl: String): Link {
     check(!baseUrl.endsWith("/"))
     check(href.startsWith("/"))
     return copy(href = baseUrl + href)


### PR DESCRIPTION
See https://github.com/readium/r2-streamer-kotlin/pull/142 for the rationale behind this change.