### PR TITLE
Fix scrolling to EPUB ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+* Scrolling to an EPUB ID (e.g. from the table of contents) when the target spans several screens.
+
 
 ## [2.0.0-beta.2]
 

--- a/r2-navigator/src/main/assets/readium/scripts/utils.js
+++ b/r2-navigator/src/main/assets/readium/scripts/utils.js
@@ -48,7 +48,7 @@ var readium = (function() {
             return;
         }
 
-        element.scrollIntoView({inline: "center"});
+        element.scrollIntoView({inline: "start", block: "start"});
         snapCurrentOffset()
     }
 


### PR DESCRIPTION
Fix scrolling to an EPUB ID (e.g. from the table of contents) when the target spans several screens. We ended up in the middle of the target instead of the beginning.