### PR TITLE
Migrate from Kotlin synthetics to ViewBinding

### DIFF
--- a/r2-navigator/build.gradle
+++ b/r2-navigator/build.gradle
@@ -9,7 +9,6 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.github.dcendents.android-maven'
 group='com.github.readium'
 
@@ -33,6 +32,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    buildFeatures {
+        viewBinding true
     }
 }
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/audiobook/R2AudiobookActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/audiobook/R2AudiobookActivity.kt
@@ -10,7 +10,6 @@ import android.widget.SeekBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
-import kotlinx.android.synthetic.main.activity_r2_audiobook.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,6 +20,7 @@ import org.readium.r2.navigator.IR2Activity
 import org.readium.r2.navigator.NavigatorDelegate
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.VisualNavigator
+import org.readium.r2.navigator.databinding.ActivityR2AudiobookBinding
 import org.readium.r2.navigator.extensions.withBaseUrl
 import org.readium.r2.shared.extensions.getPublication
 import org.readium.r2.shared.publication.*
@@ -34,6 +34,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
 
     override val currentLocator: StateFlow<Locator> get() = _currentLocator
     private val _currentLocator = MutableStateFlow(Locator(href = "#", type = ""))
+    private lateinit var binding: ActivityR2AudiobookBinding
 
     private fun notifyCurrentLocation() {
         val locator = publication.readingOrder[currentResource].let { resource ->
@@ -70,7 +71,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
         mediaPlayer.goTo(currentResource)
         seek(locator.locations)
 
-        play_pause!!.callOnClick()
+        binding.playPause.callOnClick()
         notifyCurrentLocation()
 
         return true
@@ -86,7 +87,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
         }
 
         mediaPlayer.next()
-        play_pause!!.callOnClick()
+        binding.playPause.callOnClick()
         return true
     }
 
@@ -96,7 +97,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
         }
 
         mediaPlayer.previous()
-        play_pause!!.callOnClick()
+        binding.playPause.callOnClick()
         return true
     }
 
@@ -131,7 +132,8 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_r2_audiobook)
+        binding = ActivityR2AudiobookBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         preferences = getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
 
@@ -157,7 +159,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
                 go(publication.readingOrder.first().toLocator())
             }
 
-            seekBar?.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            binding.seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
                 /**
                  * Notification that the progress level has changed. Clients can use the fromUser parameter
                  * to distinguish user-initiated changes from those that occurred programmatically.
@@ -198,7 +200,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
 
             })
 
-            play_pause!!.setOnClickListener {
+            binding.playPause.setOnClickListener {
                 mediaPlayer.let {
                     if (it.isPlaying) {
                         it.pause()
@@ -214,27 +216,27 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
                 }
             }
 
-            play_pause!!.callOnClick()
+            binding.playPause.callOnClick()
 
-            fast_forward!!.setOnClickListener {
+            binding.fastForward.setOnClickListener {
                 if (startTime.toInt() + forwardTime <= finalTime) {
                     startTime += forwardTime
                     mediaPlayer.seekTo(startTime)
                 }
             }
 
-            fast_back!!.setOnClickListener {
+            binding.fastBack.setOnClickListener {
                 if (startTime.toInt() - backwardTime > 0) {
                     startTime -= backwardTime
                     mediaPlayer.seekTo(startTime)
                 }
             }
 
-            next_chapter!!.setOnClickListener {
+            binding.nextChapter.setOnClickListener {
                 goForward(false) {}
             }
 
-            prev_chapter!!.setOnClickListener {
+            binding.prevChapter.setOnClickListener {
                 goBackward(false) {}
             }
 
@@ -245,46 +247,46 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
     private fun updateUI() {
 
         if (currentResource == publication.readingOrder.size - 1) {
-            next_chapter!!.isEnabled = false
-            next_chapter!!.alpha = .5f
+            binding.nextChapter.isEnabled = false
+            binding.nextChapter.alpha = .5f
 
         } else {
-            next_chapter!!.isEnabled = true
-            next_chapter!!.alpha = 1.0f
+            binding.nextChapter.isEnabled = true
+            binding.nextChapter.alpha = 1.0f
         }
         if (currentResource == 0) {
-            prev_chapter!!.isEnabled = false
-            prev_chapter!!.alpha = .5f
+            binding.prevChapter.isEnabled = false
+            binding.prevChapter.alpha = .5f
 
         } else {
-            prev_chapter!!.isEnabled = true
-            prev_chapter!!.alpha = 1.0f
+            binding.prevChapter.isEnabled = true
+            binding.prevChapter.alpha = 1.0f
         }
 
         val current = publication.readingOrder[currentResource]
-        chapterView!!.text = current.title
+        binding.chapterView.text = current.title
 
 
         if (mediaPlayer.isPlaying) {
-            play_pause!!.setImageDrawable(ContextCompat.getDrawable(this@R2AudiobookActivity, R.drawable.ic_pause_white_24dp))
+            binding.playPause.setImageDrawable(ContextCompat.getDrawable(this@R2AudiobookActivity, R.drawable.ic_pause_white_24dp))
         } else {
-            play_pause!!.setImageDrawable(ContextCompat.getDrawable(this@R2AudiobookActivity, R.drawable.ic_play_arrow_white_24dp))
+            binding.playPause.setImageDrawable(ContextCompat.getDrawable(this@R2AudiobookActivity, R.drawable.ic_play_arrow_white_24dp))
         }
 
         finalTime = mediaPlayer.duration
         startTime = mediaPlayer.currentPosition
 
-        seekBar!!.max = finalTime.toInt()
+        binding.seekBar.max = finalTime.toInt()
 
-        chapterTime!!.text = String.format("%d:%d",
+        binding.chapterTime.text = String.format("%d:%d",
                 TimeUnit.MILLISECONDS.toMinutes(finalTime.toLong()),
                 TimeUnit.MILLISECONDS.toSeconds(finalTime.toLong()) - TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(finalTime.toLong())))
 
-        progressTime!!.text = String.format("%d:%d",
+        binding.progressTime.text = String.format("%d:%d",
                 TimeUnit.MILLISECONDS.toMinutes(startTime.toLong()),
                 TimeUnit.MILLISECONDS.toSeconds(startTime.toLong()) - TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(startTime.toLong())))
 
-        seekBar!!.progress = startTime.toInt()
+        binding.seekBar.progress = startTime.toInt()
 
         notifyCurrentLocation()
     }
@@ -339,14 +341,14 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
                     currentResource++
                 }
                 mediaPlayer.next()
-                play_pause!!.callOnClick()
+                binding.playPause.callOnClick()
             }, 100)
         } else if (currentPosition > 0 && currentResource == publication.readingOrder.size - 1) {
             mediaPlayer.pause()
-            play_pause!!.setImageDrawable(ContextCompat.getDrawable(this@R2AudiobookActivity, R.drawable.ic_play_arrow_white_24dp))
+            binding.playPause.setImageDrawable(ContextCompat.getDrawable(this@R2AudiobookActivity, R.drawable.ic_play_arrow_white_24dp))
         } else {
             mediaPlayer.pause()
-            play_pause!!.setImageDrawable(ContextCompat.getDrawable(this@R2AudiobookActivity, R.drawable.ic_play_arrow_white_24dp))
+            binding.playPause.setImageDrawable(ContextCompat.getDrawable(this@R2AudiobookActivity, R.drawable.ic_play_arrow_white_24dp))
         }
     }
 
@@ -356,10 +358,10 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
                 mediaPlayer.let {
                     startTime = it.mediaPlayer.currentPosition.toDouble()
                 }
-                progressTime!!.text = String.format("%d:%d",
+                binding.progressTime.text = String.format("%d:%d",
                         TimeUnit.MILLISECONDS.toMinutes(startTime.toLong()),
                         TimeUnit.MILLISECONDS.toSeconds(startTime.toLong()) - TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(startTime.toLong())))
-                seekBar!!.progress = startTime.toInt()
+                binding.seekBar.progress = startTime.toInt()
 
                 notifyCurrentLocation()
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/divina/R2DiViNaActivity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/divina/R2DiViNaActivity.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.readium.r2.navigator.*
+import org.readium.r2.navigator.databinding.ActivityR2DivinaBinding
 import org.readium.r2.shared.extensions.destroyPublication
 import org.readium.r2.shared.extensions.getPublication
 import org.readium.r2.shared.publication.Publication
@@ -45,13 +46,16 @@ open class R2DiViNaActivity : AppCompatActivity(), CoroutineScope, IR2Activity, 
 
     lateinit var divinaWebView: R2BasicWebView
 
+    private lateinit var binding: ActivityR2DivinaBinding
+
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_r2_divina)
+        binding = ActivityR2DivinaBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         preferences = getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
-        divinaWebView = findViewById(R.id.divinaWebView)
+        divinaWebView = binding.divinaWebView
         //divinaWebView.listener = this
 
         publication = intent.getPublication(this)

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -24,6 +24,7 @@ import org.readium.r2.navigator.NavigatorDelegate
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.R2BasicWebView
 import org.readium.r2.navigator.VisualNavigator
+import org.readium.r2.navigator.databinding.ActivityR2ViewpagerBinding
 import org.readium.r2.navigator.extensions.htmlId
 import org.readium.r2.navigator.extensions.positionsByResource
 import org.readium.r2.navigator.extensions.withBaseUrl
@@ -76,13 +77,17 @@ class EpubNavigatorFragment private constructor(
 
     private val r2Activity: R2EpubActivity? get() = activity as? R2EpubActivity
 
+    private var _binding: ActivityR2ViewpagerBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         currentActivity = requireActivity()
-        val view = inflater.inflate(R.layout.activity_r2_viewpager, container, false)
+        _binding = ActivityR2ViewpagerBinding.inflate(inflater, container, false)
+        val view = binding.root
 
         preferences = requireContext().getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
 
-        resourcePager = view.findViewById(R.id.resourcePager)
+        resourcePager = binding.resourcePager
         resourcePager.type = Publication.TYPE.EPUB
 
         resourcesSingle = ArrayList()

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.VisualNavigator
+import org.readium.r2.navigator.databinding.ActivityR2ViewpagerBinding
 import org.readium.r2.navigator.extensions.layoutDirectionIsRTL
 import org.readium.r2.navigator.pager.R2CbzPageFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
@@ -64,6 +65,9 @@ class ImageNavigatorFragment private constructor(
     internal var currentPagerPosition: Int = 0
     internal var resources: List<String> = emptyList()
 
+    private var _binding: ActivityR2ViewpagerBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreate(savedInstanceState: Bundle?) {
         childFragmentManager.fragmentFactory = createFragmentFactory {
             R2CbzPageFragment(publication) { x, y -> this.listener?.onTap(PointF(x, y)) }
@@ -73,10 +77,11 @@ class ImageNavigatorFragment private constructor(
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         currentActivity = requireActivity()
-        val view = inflater.inflate(R.layout.activity_r2_viewpager, container, false)
+        _binding = ActivityR2ViewpagerBinding.inflate(inflater, container, false)
+        val view = binding.root
 
         preferences = requireContext().getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
-        resourcePager = view.findViewById(R.id.resourcePager)
+        resourcePager = binding.resourcePager
         resourcePager.type = Publication.TYPE.CBZ
 
         positions = runBlocking { publication.positions() }

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
@@ -123,6 +123,11 @@ class ImageNavigatorFragment private constructor(
         notifyCurrentLocation()
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     @Deprecated("Use goForward instead", replaceWith = ReplaceWith("goForward()"), level = DeprecationLevel.ERROR)
     fun nextResource(v: View?) {
         goForward()

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2CbzPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2CbzPageFragment.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.readium.r2.navigator.R
+import org.readium.r2.navigator.databinding.ViewpagerFragmentCbzBinding
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
 import kotlin.coroutines.CoroutineContext
@@ -39,10 +40,14 @@ class R2CbzPageFragment(private val publication: Publication, private val onTapL
     private lateinit var containerView: View
     private lateinit var photoView: PhotoView
 
+    private var _binding: ViewpagerFragmentCbzBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 
-        containerView = inflater.inflate(R.layout.viewpager_fragment_cbz, container, false)
-        photoView = containerView.findViewById(R.id.imageView)
+        _binding = ViewpagerFragmentCbzBinding.inflate(inflater, container, false)
+        containerView = binding.root
+        photoView = binding.imageView
         photoView.setOnViewTapListener { _, x, y -> onTapListener(x, y) }
 
         setupPadding()

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2CbzPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2CbzPageFragment.kt
@@ -63,6 +63,11 @@ class R2CbzPageFragment(private val publication: Publication, private val onTapL
        return containerView
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     private fun setupPadding() {
         updatePadding()
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -30,6 +30,7 @@ import org.readium.r2.navigator.Navigator
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.R2BasicWebView
 import org.readium.r2.navigator.R2WebView
+import org.readium.r2.navigator.databinding.ViewpagerFragmentEpubBinding
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.extensions.htmlId
 import org.readium.r2.shared.SCROLL_REF
@@ -50,13 +51,17 @@ class R2EpubPageFragment : Fragment() {
     private lateinit var containerView: View
     private lateinit var preferences: SharedPreferences
 
+    private var _binding: ViewpagerFragmentEpubBinding? = null
+    private val binding get() = _binding!!
+
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val navigatorFragment = parentFragment as EpubNavigatorFragment
-        containerView = inflater.inflate(R.layout.viewpager_fragment_epub, container, false)
+        _binding = ViewpagerFragmentEpubBinding.inflate(inflater, container, false)
+        containerView = binding.root
         preferences = activity?.getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)!!
 
-        val webView = containerView.findViewById(R.id.webView) as R2WebView
+        val webView = binding.webView
         this.webView = webView
 
         webView.navigator = parentFragment as Navigator

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -238,6 +238,11 @@ class R2EpubPageFragment : Fragment() {
         }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     private fun setupPadding() {
         updatePadding()
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
@@ -105,6 +105,12 @@ class R2FXLPageFragment : Fragment() {
         }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _singleBinding = null
+        _doubleBinding = null
+    }
+
     @SuppressLint("SetJavaScriptEnabled")
     private fun setupWebView(webView: R2BasicWebView, resourceUrl: String?) {
         webViews.add(webView)

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
@@ -23,6 +23,8 @@ import androidx.webkit.WebViewClientCompat
 import org.readium.r2.navigator.Navigator
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.R2BasicWebView
+import org.readium.r2.navigator.databinding.FragmentFxllayoutDoubleBinding
+import org.readium.r2.navigator.databinding.FragmentFxllayoutSingleBinding
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.epub.fxl.R2FXLLayout
 import org.readium.r2.navigator.epub.fxl.R2FXLOnDoubleTapListener
@@ -37,18 +39,25 @@ class R2FXLPageFragment : Fragment() {
 
     private var webViews = mutableListOf<WebView>()
 
+    private var _doubleBinding: FragmentFxllayoutDoubleBinding? = null
+    private val doubleBinding get() = _doubleBinding!!
+
+    private var _singleBinding: FragmentFxllayoutSingleBinding? = null
+    private val singleBinding get() = _singleBinding!!
+
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 
         secondResourceUrl?.let {
-            val view: View = inflater.inflate(R.layout.fragment_fxllayout_double, container, false)
+            _doubleBinding = FragmentFxllayoutDoubleBinding.inflate(inflater, container, false)
+            val view: View = doubleBinding.root
             view.setPadding(0, 0, 0, 0)
 
-            val r2FXLLayout = view.findViewById<View>(R.id.r2FXLLayout) as R2FXLLayout
+            val r2FXLLayout = doubleBinding.r2FXLLayout
             r2FXLLayout.isAllowParentInterceptOnScaled = true
 
-            val left = view.findViewById<View>(R.id.firstWebView) as R2BasicWebView
-            val right = view.findViewById<View>(R.id.secondWebView) as R2BasicWebView
+            val left = doubleBinding.firstWebView
+            val right = doubleBinding.secondWebView
 
             setupWebView(left, firstResourceUrl)
             setupWebView(right, secondResourceUrl)
@@ -62,13 +71,14 @@ class R2FXLPageFragment : Fragment() {
 
             return view
         }?:run {
-            val view: View = inflater.inflate(R.layout.fragment_fxllayout_single, container, false)
+            _singleBinding = FragmentFxllayoutSingleBinding.inflate(inflater, container, false)
+            val view: View = singleBinding.root
             view.setPadding(0, 0, 0, 0)
 
-            val r2FXLLayout = view.findViewById<View>(R.id.r2FXLLayout) as R2FXLLayout
+            val r2FXLLayout = singleBinding.r2FXLLayout
             r2FXLLayout.isAllowParentInterceptOnScaled = true
 
-            val webview = view.findViewById<View>(R.id.webViewSingle) as R2BasicWebView
+            val webview = singleBinding.webViewSingle
 
             setupWebView(webview, firstResourceUrl)
 


### PR DESCRIPTION
https://github.com/readium/r2-testapp-kotlin/issues/407, partially finishes that.  With Kotlin Android Extensions being deprecated, Google suggests migrating to ViewBinding.  Apart from enabling ViewBinding and removing the kotlin-android-extensions plugin, the only files that were changed were fragments or activities that were using Kotlin synthetics and/or calling `findViewById`.