### PR TITLE
Go to a Locator using its text context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
+**Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
 ## [Unreleased]
 
@@ -68,7 +68,7 @@ progression. Now if no reading progression is set, the `effectiveReadingProgress
 ### Added
 
 * Support for the new `Publication` model using the [Content Protection](https://readium.org/architecture/proposals/006-content-protection) for DRM rights and the [Fetcher](https://readium.org/architecture/proposals/002-composite-fetcher-api) for resource access.
-* (*Experimental*) New `Fragment` implementations as an alternative to the legacy `Activity` ones (contributed by [@johanpoirier](https://github.com/readium/r2-navigator-kotlin/pull/148)).
+* (*alpha*) New `Fragment` implementations as an alternative to the legacy `Activity` ones (contributed by [@johanpoirier](https://github.com/readium/r2-navigator-kotlin/pull/148)).
   * The fragments are chromeless, to let you customize the reading UX.
   * To create the fragments use the matching factory such as `EpubNavigatorFragment.createFactory()`, as showcased in `R2EpubActivity`.
   * At the moment, highlights and TTS are not yet supported in the new EPUB navigator `Fragment`.
@@ -93,7 +93,7 @@ progression. Now if no reading progression is set, the `effectiveReadingProgress
 ### Added
 
 * The [position](https://github.com/readium/architecture/tree/master/models/locators/positions) is now reported in the locators for EPUB, CBZ and PDF.
-* (*Experimental*) [PDF navigator](https://github.com/readium/r2-navigator-kotlin/pull/130).
+* (*alpha*) [PDF navigator](https://github.com/readium/r2-navigator-kotlin/pull/130).
   * Supports both single PDF and LCP protected PDF.
   * As a proof of concept, [it is implemented using `Fragment` instead of `Activity`](https://github.com/readium/r2-navigator-kotlin/issues/115). `R2PdfActivity` showcases how to use the `PdfNavigatorFragment` with the new `NavigatorFragmentFactory`.
   * The navigator is based on [AndroidPdfViewer](https://github.com/barteksc/AndroidPdfViewer), which may increase the size of your apps. Please open an issue if this is a problem for you, as we are considering different solutions to fix this in a future release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!--## [Unreleased]-->
+## [Unreleased]
+
+### Added
+
+* The EPUB navigator is now able to navigate to a `Locator` using its `text` context. This is useful for search results or highlights missing precise locations.
+
+### Changed
+
+* The order of precedence of `Locator` locations in the reflowable EPUB navigator is: `text`, HTML ID, then `progression`. The navigator will now fallback on less precise locations in case of failure.
+
 
 ## [2.0.0]
 

--- a/r2-navigator/src/main/assets/readium/scripts/gestures.js
+++ b/r2-navigator/src/main/assets/readium/scripts/gestures.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2021 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
 (function() {
   window.addEventListener('DOMContentLoaded', function(event) {
     document.addEventListener('click', onClick, false);

--- a/r2-navigator/src/main/assets/readium/scripts/utils.js
+++ b/r2-navigator/src/main/assets/readium/scripts/utils.js
@@ -160,6 +160,9 @@ var readium = (function() {
             }
         }
 
+        // Resets the selection otherwise the last found occurrence will be highlighted.
+        selection.clear();
+
         snapCurrentOffset();
         return found;
     }

--- a/r2-navigator/src/main/assets/readium/scripts/utils.js
+++ b/r2-navigator/src/main/assets/readium/scripts/utils.js
@@ -45,11 +45,12 @@ var readium = (function() {
     function scrollToId(id) {
         var element = document.getElementById(id);
         if (!element) {
-            return;
+            return false;
         }
 
         element.scrollIntoView({inline: "start", block: "start"});
         snapCurrentOffset()
+        return true;
     }
 
     // Position must be in the range [0 - 1], 0-100%.
@@ -69,6 +70,98 @@ var readium = (function() {
             var offset = documentWidth * position * factor;
             document.scrollingElement.scrollLeft = snapOffset(offset);
         }
+    }
+
+    // Scrolls to the first occurrence of the given text snippet.
+    //
+    // The expected text argument is a Locator Text object, as defined here:
+    // https://readium.org/architecture/models/locators/
+    function scrollToText(text) {
+        // Wrapper around a browser Selection object.
+        function Selection(selection) {
+            this.selection = selection;
+            this.markedRanges = []
+        }
+
+        // Removes all the ranges of the selection.
+        Selection.prototype.clear = function() {
+            this.selection.removeAllRanges();
+        }
+
+        // Saves the current selection ranges, to be restored later with reset().
+        Selection.prototype.mark = function() {
+            this.markedRanges = []
+            for (var i = 0; i < this.selection.rangeCount; i++) {
+                this.markedRanges.push(this.selection.getRangeAt(i));
+            }
+        }
+
+        // Resets the selection with ranges previously saved with mark().
+        Selection.prototype.reset = function() {
+            this.clear();
+            for (var i = 0; i < this.markedRanges.length; i++) {
+                this.selection.addRange(this.markedRanges[i]);
+            }
+        }
+
+        // Returns the text content of the selection.
+        Selection.prototype.toString = function() {
+            return this.selection.toString();
+        }
+
+        // Extends the selection by moving the start and end positions by the given offsets.
+        Selection.prototype.adjust = function(offset, length) {
+            for (var i = 0; i <= Math.abs(offset); i++) {
+                var direction = (offset >= 0 ? "forward" : "backward")
+                this.selection.modify("move", direction, "character");
+            }
+            for (var i = 0; i <= length; i++) {
+                this.selection.modify("extend", "forward", "character");
+            }
+        }
+
+        Selection.prototype.isEmpty = function() {
+            return this.selection.isCollapsed
+        }
+
+        function removeWhitespaces(s) {
+            return s.replace(/\s+/g, "");
+        }
+
+        var highlight = text.highlight;
+        var before  = text.before || "";
+        var after  = text.after || "";
+        var snippet = before + highlight + after;
+        var safeSnippet = removeWhitespaces(snippet);
+
+        if (!highlight || !safeSnippet) {
+            return false;
+        }
+
+        var selection = new Selection(window.getSelection());
+        // We need to reset any selection to begin the search from the start of the resource.
+        selection.clear();
+
+        var found = false;
+        while (window.find(text.highlight, true)) {
+            if (selection.isEmpty()) {
+                break; // Prevents infinite loop in edge cases.
+            }
+
+            // Get the surrounding context to compare to the expected snippet.
+            selection.mark();
+            selection.adjust(-before.length, snippet.length);
+            var safeSelection = removeWhitespaces(selection.toString());
+            selection.reset();
+
+            if (safeSelection != "" && (safeSnippet.includes(safeSelection) || safeSelection.includes(safeSnippet))) {
+                found = true;
+                break;
+            }
+        }
+
+        snapCurrentOffset();
+        return found;
     }
 
     function scrollToStart() {
@@ -162,6 +255,7 @@ var readium = (function() {
     return {
         'scrollToId': scrollToId,
         'scrollToPosition': scrollToPosition,
+        'scrollToText': scrollToText,
         'scrollLeft': scrollLeft,
         'scrollRight': scrollRight,
         'scrollToStart': scrollToStart,

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -38,6 +38,8 @@ import org.readium.r2.shared.extensions.tryOrNull
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.util.Href
 import timber.log.Timber
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 
 /**
@@ -358,12 +360,16 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
         runJavaScript("readium.scrollToEnd();")
     }
 
-    fun scrollToId(htmlId: String) {
-        runJavaScript("readium.scrollToId(\"$htmlId\");")
-    }
+    suspend fun scrollToId(htmlId: String): Boolean =
+        runJavaScriptSuspend("readium.scrollToId(\"$htmlId\");").toBoolean()
 
     fun scrollToPosition(progression: Double) {
         runJavaScript("readium.scrollToPosition(\"$progression\");")
+    }
+
+    suspend fun scrollToText(text: Locator.Text): Boolean {
+        val json = text.toJSON().toString()
+        return runJavaScriptSuspend("readium.scrollToText($json);").toBoolean()
     }
 
     fun setScrollMode(scrollMode: Boolean) {
@@ -419,6 +425,12 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
 
         this.evaluateJavascript(javascript) { result ->
             if (callback != null) callback(result)
+        }
+    }
+
+    private suspend fun runJavaScriptSuspend(javascript: String): String = suspendCoroutine { cont ->
+        runJavaScript(javascript) { result ->
+            cont.resume(result)
         }
     }
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -121,8 +121,9 @@ class R2EpubPageFragment : Fragment() {
                     (epubNavigator?.resourcePager?.adapter as? R2PagerAdapter)?.getCurrentFragment() as? R2EpubPageFragment
 
                 if (currentFragment != null && this@R2EpubPageFragment.tag == currentFragment.tag) {
-                    var locations = epubNavigator.pendingLocator?.locations
+                    val locator = epubNavigator.pendingLocator
                     epubNavigator.pendingLocator = null
+                    var locations = locator?.locations
 
                     // TODO this seems to be needed, will need to test more
                     if (url != null && url.indexOf("#") > 0) {
@@ -137,31 +138,42 @@ class R2EpubPageFragment : Fragment() {
                             // FIXME: We need a better way to wait, because if the value is too low it fails
                             delay(200)
 
+                            val text = locator?.text
+                            if (text?.highlight != null) {
+                                if (currentWebView.scrollToText(text)) {
+                                    return@launchWhenStarted
+                                }
+
+                                // The delay is necessary before falling back on the other
+                                // locations, because scrollToText() is moving the scroll position
+                                // while looking for the text snippet.
+                                delay(100)
+                            }
+
                             val htmlId = locations.htmlId
+                            if (htmlId != null && currentWebView.scrollToId(htmlId)) {
+                                return@launchWhenStarted
+                            }
+
                             var progression = locations.progression
+                            if (progression != null) {
+                                // We need to reverse the progression with RTL because the Web View
+                                // always scrolls from left to right, no matter the reading direction.
+                                progression =
+                                    if (webView.scrollMode || navigatorFragment.readingProgression == ReadingProgression.LTR) progression
+                                    else 1 - progression
 
-                            when {
-                                htmlId != null -> currentWebView.scrollToId(htmlId)
+                                if (webView.scrollMode) {
+                                    currentWebView.scrollToPosition(progression)
 
-                                progression != null -> {
-                                    // We need to reverse the progression with RTL because the Web View
-                                    // always scrolls from left to right, no matter the reading direction.
-                                    progression =
-                                        if (webView.scrollMode || navigatorFragment.readingProgression == ReadingProgression.LTR) progression
-                                        else 1 - progression
-
-                                    if (webView.scrollMode) {
-                                        currentWebView.scrollToPosition(progression)
-
-                                    } else {
-                                        // Figure out the target web view "page" from the requested
-                                        // progression.
-                                        var item = (progression * currentWebView.numPages).roundToInt()
-                                        if (navigatorFragment.readingProgression == ReadingProgression.RTL && item > 0) {
-                                            item -= 1
-                                        }
-                                        currentWebView.setCurrentItem(item, false)
+                                } else {
+                                    // Figure out the target web view "page" from the requested
+                                    // progression.
+                                    var item = (progression * currentWebView.numPages).roundToInt()
+                                    if (navigatorFragment.readingProgression == ReadingProgression.RTL && item > 0) {
+                                        item -= 1
                                     }
+                                    currentWebView.setCurrentItem(item, false)
                                 }
                             }
                         }

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
@@ -31,6 +31,7 @@ import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.services.isRestricted
 import org.readium.r2.shared.publication.services.positionsByReadingOrder
+import org.readium.r2.shared.util.use
 import timber.log.Timber
 
 /**


### PR DESCRIPTION
### Added

* The EPUB navigator is now able to navigate to a `Locator` using its `text` context. This is useful for search results or highlights missing precise locations.

### Changed

* The order of precedence of `Locator` locations in the reflowable EPUB navigator is: `text`, HTML ID, then `progression`. The navigator will now fallback on less precise locations in case of failure.