### PR TITLE
Added support for page events from fragment

### DIFF
--- a/r2-navigator/src/main/java/org/readium/r2/navigator/IR2Activity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/IR2Activity.kt
@@ -20,7 +20,13 @@ import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression
 
-interface IR2Activity {
+interface IR2Listener {
+    fun onPageChanged(pageIndex: Int, totalPages: Int, url: String) {}
+    fun onPageEnded(end: Boolean) {}
+    fun onPageLoaded() {}
+}
+
+interface IR2Activity: IR2Listener {
 
     val publication: Publication
     val preferences: SharedPreferences
@@ -37,9 +43,6 @@ interface IR2Activity {
     fun toggleActionBar(v: View? = null) {}
     fun nextResource(v: View? = null) {}
     fun previousResource(v: View? = null) {}
-    fun onPageChanged(pageIndex: Int, totalPages: Int, url: String) {}
-    fun onPageEnded(end: Boolean) {}
-    fun onPageLoaded() {}
     fun highlightActivated(id: String) {}
     fun highlightAnnotationMarkActivated(id: String) {}
 }

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/IR2Activity.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/IR2Activity.kt
@@ -20,13 +20,7 @@ import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression
 
-interface IR2Listener {
-    fun onPageChanged(pageIndex: Int, totalPages: Int, url: String) {}
-    fun onPageEnded(end: Boolean) {}
-    fun onPageLoaded() {}
-}
-
-interface IR2Activity: IR2Listener {
+interface IR2Activity {
 
     val publication: Publication
     val preferences: SharedPreferences
@@ -43,6 +37,9 @@ interface IR2Activity: IR2Listener {
     fun toggleActionBar(v: View? = null) {}
     fun nextResource(v: View? = null) {}
     fun previousResource(v: View? = null) {}
+    fun onPageChanged(pageIndex: Int, totalPages: Int, url: String) {}
+    fun onPageEnded(end: Boolean) {}
+    fun onPageLoaded() {}
     fun highlightActivated(id: String) {}
     fun highlightAnnotationMarkActivated(id: String) {}
 }

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -20,10 +20,7 @@ import androidx.viewpager.widget.ViewPager
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import org.readium.r2.navigator.NavigatorDelegate
-import org.readium.r2.navigator.R
-import org.readium.r2.navigator.R2BasicWebView
-import org.readium.r2.navigator.VisualNavigator
+import org.readium.r2.navigator.*
 import org.readium.r2.navigator.extensions.htmlId
 import org.readium.r2.navigator.extensions.positionsByResource
 import org.readium.r2.navigator.extensions.withBaseUrl
@@ -53,7 +50,7 @@ class EpubNavigatorFragment private constructor(
     internal val listener: Listener? = null
 ): Fragment(), CoroutineScope by MainScope(), VisualNavigator, R2BasicWebView.Listener {
 
-    interface Listener: VisualNavigator.Listener
+    interface Listener: VisualNavigator.Listener, IR2Listener
 
     init {
         require(!publication.isRestricted) { "The provided publication is restricted. Check that any DRM was properly unlocked using a Content Protection."}
@@ -73,8 +70,6 @@ class EpubNavigatorFragment private constructor(
     private lateinit var currentActivity: FragmentActivity
 
     internal var navigatorDelegate: NavigatorDelegate? = null
-
-    private val r2Activity: R2EpubActivity? get() = activity as? R2EpubActivity
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         currentActivity = requireActivity()
@@ -283,19 +278,19 @@ class EpubNavigatorFragment private constructor(
     // R2BasicWebView.Listener
 
     override fun onPageLoaded() {
-        r2Activity?.onPageLoaded()
+        listener?.onPageLoaded()
     }
 
     override fun onPageChanged(pageIndex: Int, totalPages: Int, url: String) {
-        r2Activity?.onPageChanged(pageIndex = pageIndex, totalPages = totalPages, url = url)
+        listener?.onPageChanged(pageIndex = pageIndex, totalPages = totalPages, url = url)
     }
 
     override fun onPageEnded(end: Boolean) {
-        r2Activity?.onPageEnded(end)
+        listener?.onPageEnded(end)
     }
 
     override fun onScroll() {
-        val activity = r2Activity ?: return
+        val activity = activity as? R2EpubActivity ?: return
         if (activity.supportActionBar?.isShowing == true && activity.allowToggleActionBar) {
             resourcePager.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
@@ -315,11 +310,13 @@ class EpubNavigatorFragment private constructor(
     }
 
     override fun onHighlightActivated(id: String) {
-        r2Activity?.highlightActivated(id)
+        val activity = activity as? R2EpubActivity ?: return
+        activity?.highlightActivated(id)
     }
 
     override fun onHighlightAnnotationMarkActivated(id: String) {
-        r2Activity?.highlightAnnotationMarkActivated(id)
+        val activity = activity as? R2EpubActivity ?: return
+        activity?.highlightAnnotationMarkActivated(id)
     }
 
     override fun goForward(animated: Boolean, completion: () -> Unit): Boolean {

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -56,7 +56,7 @@ class EpubNavigatorFragment private constructor(
 ): Fragment(), CoroutineScope by MainScope(), VisualNavigator, R2BasicWebView.Listener {
 
     interface PaginationListener {
-        fun onPageChanged(pageNumber: Int, totalPages: Int, locator: Locator) {}
+        fun onPageChanged(pageIndex: Int, totalPages: Int, locator: Locator) {}
         fun onPageLoaded() {}
     }
 
@@ -313,7 +313,8 @@ class EpubNavigatorFragment private constructor(
             }
 
             val locator = positions[positionIndex].copyWithLocations(progression = progression)
-            paginationListener.onPageChanged(pageIndex, totalPages, locator)
+            // Pageindex is actually the page number so to get a zero based index we subtract one.
+            paginationListener.onPageChanged(pageIndex - 1, totalPages, locator)
         }
     }
 


### PR DESCRIPTION
When using fragments the only way of being notified of a page change is to observe the `currentLocator` property on the fragment.

There is a small problem with this for epub fragments. The current locator changes multiple times when navigating to a `Locator`. This is caused by the fact that the viewPager must load the requested chapter (which causes a `currentLocator` update telling us that we are on the first page in the chapter) before it can navigate to the correct position in the chapter (which again causes an update to the `currentLocator`).

In the fragment there is a mechanism for notifying the parent activity when the page has changed. The problem with the current implementation is that it assumes that this is an `R2EpubActivity` - which is not true when using a fragment to build a custom UX around the reader.

**This PR fixes** this by removing the hard dependency on `R2EpubActivity` in the fragment. A new interface, `IR2Listener`, has been split out from the `IR2Activity` interface and replaces the activity member in the `R2EpubNavigatorFragment`. The `listener` member now supports this new interface and will call its corresponding methods when the active page changes.