### PR TITLE
Fallback on locations.position if a PDF page= fragment is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file.
 * Upgraded to Kotlin 1.5.21 and Gradle 7.1.1
 * The order of precedence of `Locator` locations in the reflowable EPUB navigator is: `text`, HTML ID, then `progression`. The navigator will now fallback on less precise locations in case of failure.
 
+### Fixed
+
+* When restoring a `Locator`, The PDF navigator now falls back on `locations.position` if the `page=` fragment identifier is missing.
+
 
 ## [2.0.0]
 

--- a/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
+++ b/r2-navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
@@ -154,8 +154,10 @@ class PdfNavigatorFragment internal constructor(
     private val _currentLocator = MutableStateFlow(initialLocator ?: publication.readingOrder.first().toLocator())
 
     override fun go(locator: Locator, animated: Boolean, completion: () -> Unit): Boolean {
-        val page = ((locator.locations.page ?: 1) - 1).coerceAtLeast(0)
-        return goToHref(locator.href, page, animated, completion)
+        // FIXME: `position` is relative to the full publication, which would cause an issue for a publication containing several PDFs resources. Only publications with a single PDF resource are supported at the moment, so we're fine.
+        val pageNumber = locator.locations.page ?: locator.locations.position ?: 1
+        val pageIndex = (pageNumber - 1).coerceAtLeast(0)
+        return goToHref(locator.href, pageIndex, animated, completion)
     }
 
     override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean =


### PR DESCRIPTION
### Fixed

* When restoring a `Locator`, The PDF navigator now falls back on `locations.position` if the `page=` fragment identifier is missing.


This is a workaround for a bug introduced in the test app which might also occur in other apps. The `page=` fragment identifier was not saved in the database when saving a bookmark, which made them unusable with the `PdfNavigatorFragment`. Since `locations.position` is virtually equivalent to the `page=` fragment, this is a suitable fallback.